### PR TITLE
이미지 불러오기 에러 시 기본이미지로 대체

### DIFF
--- a/components/challenge/ChallengeApplyModal.tsx
+++ b/components/challenge/ChallengeApplyModal.tsx
@@ -291,9 +291,13 @@ const ChallengeApplyModal = ({ challengeId, onClose }: ChallengeApplyModalProps)
                             layout="fill"
                             objectFit="cover"
                             className="rounded-t-lg"
-                        />
-                    </div>
-                    <button
+                            onError={e => {
+                            const target = e.target as HTMLImageElement;
+                            target.src = '/images/charactors/gamza.png';
+                          }}
+                       />
+                   </div>
+                   <button
                         onClick={onClose}
                         className="absolute top-3 right-3 bg-black/40 rounded-full p-1 text-white hover:bg-black/60 transition-colors"
                         aria-label="닫기"

--- a/components/challenge/ChallengeDetailClient.tsx
+++ b/components/challenge/ChallengeDetailClient.tsx
@@ -362,6 +362,10 @@ const ChallengeDetailClient = ({ challengeId }: { challengeId: BigInt }) => {
                           alt={`${member.nickname}의 인증 사진`}
                           layout="fill"
                           className="object-cover rounded-lg"
+                          onError={e => {
+                            const target = e.target as HTMLImageElement;
+                            target.src = '/images/charactors/gamza.png';
+                          }}
                         />
                       </div>
                     ) : (
@@ -490,6 +494,10 @@ const ChallengeDetailClient = ({ challengeId }: { challengeId: BigInt }) => {
                 width={500}
                 height={500}
                 className="w-full h-auto object-contain rounded-lg"
+                onError={e => {
+                  const target = e.target as HTMLImageElement;
+                  target.src = '/images/charactors/gamza.png';
+                }}
               />
             </div>
             <div className="text-center">

--- a/components/challenge/ChallengeEditForm.tsx
+++ b/components/challenge/ChallengeEditForm.tsx
@@ -37,7 +37,10 @@ export default function ChallengeEditForm({ challengeId }: ChallengeEditFormProp
         <div className="mb-6">
           <label className="block text-sm font-medium mb-1">대표사진</label>
           <div className="flex items-center space-x-4">
-            <Image src={image} alt="대표사진" width={56} height={56} className="rounded-full border" />
+            <Image src={image} alt="대표사진" width={56} height={56} className="rounded-full border" onError={(e) => {
+              const target = e.target as HTMLImageElement;
+              target.src = "/images/charactors/gamza.png";
+            }} />
             {/* 실제 구현 시 파일 업로드 처리 필요 */}
             <button type="button" className="text-xs text-gray-500 border px-2 py-1 rounded">이미지 변경</button>
           </div>

--- a/components/chat/ChatListItem.tsx
+++ b/components/chat/ChatListItem.tsx
@@ -20,6 +20,10 @@ export default function ChatListItem({ chat, onClick }: ChatListItemProps) {
           width={56}
           height={56}
           className="flex-shrink-0 rounded-full"
+          onError={e => {
+            const target = e.target as HTMLImageElement;
+            target.src = '/images/charactors/gamza.png';
+          }}
         />
         <div className="min-w-0">
           <div className="flex items-baseline space-x-2">

--- a/components/chat/ChatRoom.tsx
+++ b/components/chat/ChatRoom.tsx
@@ -144,6 +144,10 @@ export default function ChatRoom({
             width={36}
             height={36}
             className="rounded-full border"
+            onError={e => {
+              const target = e.target as HTMLImageElement;
+              target.src = '/images/charactors/gamza.png';
+            }}
           />
           <span className="font-bold text-base text-gray-800 dark:text-white">
             {roomName}
@@ -260,6 +264,10 @@ export default function ChatRoom({
                           width={32}
                           height={32}
                           className="rounded-full border self-start"
+                          onError={e => {
+                            const target = e.target as HTMLImageElement;
+                            target.src = '/images/charactors/gamza.png';
+                          }}
                         />
                         <div className="flex flex-col items-start">
                           <div className="text-xs text-gray-500 dark:text-gray-400 ml-1 mb-1">

--- a/components/common/ContentHeader.tsx
+++ b/components/common/ContentHeader.tsx
@@ -55,6 +55,10 @@ const ContentHeader = ({
                 alt="Profile"
                 fill
                 className="rounded-full"
+                onError={e => {
+                  const target = e.target as HTMLImageElement;
+                  target.src = '/images/charactors/gamza.png';
+                }}
               />
             </div>
           </div>
@@ -80,6 +84,10 @@ const ContentHeader = ({
               alt="Profile"
               fill
               className="rounded-full"
+              onError={e => {
+                const target = e.target as HTMLImageElement;
+                target.src = '/images/charactors/gamza.png';
+              }}
             />
           </div>
         </div>

--- a/components/mypage/MyPageChallengeHistoryComponent.tsx
+++ b/components/mypage/MyPageChallengeHistoryComponent.tsx
@@ -126,6 +126,10 @@ export default function MyPageChallengeHistoryComponent() {
                     width={48}
                     height={48}
                     className="w-full h-full object-cover"
+                    onError={e => {
+                      const target = e.target as HTMLImageElement;
+                      target.src = '/images/charactors/gamza.png';
+                    }}
                   />
                 </div>
                 <div className="flex-1 min-w-0">

--- a/components/mypage/MyPageMainComponent.tsx
+++ b/components/mypage/MyPageMainComponent.tsx
@@ -58,6 +58,10 @@ export default function MyPageMainComponent() {
                   width={56}
                   height={56}
                   className="w-full h-full object-cover object-center"
+                  onError={e => {
+                    const target = e.target as HTMLImageElement;
+                    target.src = '/images/charactors/gamza.png';
+                  }}
                 />
               </div>
               <div>

--- a/components/mypage/MyPageProfileComponent.tsx
+++ b/components/mypage/MyPageProfileComponent.tsx
@@ -253,6 +253,10 @@ export default function MyPageComponent() {
               width={112}
               height={112}
               className="w-full h-full object-cover object-center"
+              onError={e => {
+                const target = e.target as HTMLImageElement;
+                target.src = '/images/charactors/gamza.png';
+              }}
             />
           </div>
           <input

--- a/components/mypage/NicknameChangeComponent.tsx
+++ b/components/mypage/NicknameChangeComponent.tsx
@@ -76,6 +76,10 @@ export default function NicknameChangeComponent() {
             width={100}
             height={100}
             className="rounded-full object-cover"
+            onError={e => {
+              const target = e.target as HTMLImageElement;
+              target.src = '/images/charactors/gamza.png';
+            }}
           />
         </div>
       </div>

--- a/components/signup/SignUpForm.tsx
+++ b/components/signup/SignUpForm.tsx
@@ -113,6 +113,10 @@ const SignUpForm = ({ onNext, initialData }: SignUpFormProps) => {
                 width={112}
                 height={112}
                 className="w-full h-full object-cover object-center"
+                onError={e => {
+                  const target = e.target as HTMLImageElement;
+                  target.src = '/images/charactors/gamza.png';
+                }}
               />
             </div>
             {/* 카메라 아이콘 */}

--- a/components/verification/CompletedVerificationCard.tsx
+++ b/components/verification/CompletedVerificationCard.tsx
@@ -26,6 +26,10 @@ const CompletedVerificationCard = ({
         layout="fill"
         objectFit="cover"
         className="transform hover:scale-105 transition-transform duration-300"
+        onError={e => {
+          const target = e.target as HTMLImageElement;
+          target.src = '/images/charactors/gamza.png';
+        }}
       />
       <div className="absolute bottom-2 left-2 right-2 bg-black bg-opacity-30 text-white p-3 rounded-md">
         <h3 className="font-bold truncate">{verification.title}</h3>

--- a/components/verification/VerifiableChallengeCard.tsx
+++ b/components/verification/VerifiableChallengeCard.tsx
@@ -38,7 +38,17 @@ const VerifiableChallengeCard = ({ challenge }: VerifiableChallengeCardProps) =>
       <div className="flex flex-col flex-1">
         <div className="flex items-center">
           <div className="relative w-20 h-20 mr-4 flex-shrink-0 overflow-hidden">
-            <Image src={challenge.image} alt={challenge.title} width={80} height={80} className="rounded-lg object-cover w-full h-full" />
+            <Image
+              src={challenge.image}
+              alt={challenge.title}
+              width={80}
+              height={80}
+              className="rounded-lg object-cover w-full h-full"
+              onError={e => {
+                const target = e.target as HTMLImageElement;
+                target.src = '/images/charactors/gamza.png';
+              }}
+            />
           </div>
           <div>
             <span className={`px-2 py-0.5 text-xs font-semibold rounded-full mb-1 inline-block ${getStatusChipStyle(status)}`}>


### PR DESCRIPTION
## 📌 관련 이슈 (해당하는 경우)

<!-- 예시: closed: #123
     여러 개일 경우: closed: #123, closed: #124 -->
- closed: #110

## 🙏 리뷰 요청
<!-- 리뷰는 최소 2명에게 요청해주세요. -->
- Reviewers: 

## ✨ 작업 내용 (이슈가 없을 경우 명시적으로 작성)

<!-- 아래 항목은 이슈가 없을 때 반드시 작성해주세요. -->
- 작업 요약:
  - 전체 애플리케이션의 `Image` 컴포넌트에 `onError` 핸들러를 추가했습니다.
  - 이미지 로드에 실패할 경우, 기본 감자 캐릭터 이미지(`/images/charactors/gamza.png`)가 표시되도록 수정하여 깨진 이미지가 보이지 않도록 처리했습니다.
